### PR TITLE
Fix image path in doc and description

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ build:
             - compiled-$CI_BUILD_TAG.exe
             - doc-$CI_BUILD_TAG.pdf
 publish:
-    image: inetprocess/gitlab-release
+    image: stratosgear/gitlab-release
     stage: publish
     only:
         - tags

--- a/gitlab-release
+++ b/gitlab-release
@@ -143,7 +143,7 @@ build:
             - compiled-$CI_BUILD_TAG.exe
             - doc-$CI_BUILD_TAG.pdf
 publish:
-    image: inetprocess/gitlab-release
+    image: stratosgear/gitlab-release
     stage: publish
     only:
         - tags


### PR DESCRIPTION
Forked Docker image seems to be hosted at https://hub.docker.com/r/stratosgear/gitlab-release